### PR TITLE
Correct order of tracks when playing multi-disc albums

### DIFF
--- a/Sources/WifiRemote/PluginConnection/MpMusicHelper.cs
+++ b/Sources/WifiRemote/PluginConnection/MpMusicHelper.cs
@@ -42,7 +42,7 @@ namespace WifiRemote.PluginConnection
         public static void PlayAlbum(String albumArtist, String album, int startPos)
         {
             List<Song> songs = new List<Song>();
-            string sql = String.Format("select * from tracks where strAlbumArtist like '%{0}%' AND strAlbum LIKE '%{1}%' order by iTrack ASC",
+            string sql = String.Format("select * from tracks where strAlbumArtist like '%{0}%' AND strAlbum LIKE '%{1}%' order by iDisc,iTrack ASC",
                 DatabaseUtility.RemoveInvalidChars(albumArtist),
                 DatabaseUtility.RemoveInvalidChars(album));
             MusicDatabase.Instance.GetSongsByFilter(sql, out songs, "tracks");


### PR DESCRIPTION
SQL query output for PlayAlbum action is now ordered by iDisc first to prevent incorrect playlist sequence for albums which have more discs (1st track from 1st disc >>> 1st track from 2nd disc >>> 2nd track from 1st disc >>> 2nd track from 2nd disc >>> ... )
