### PR TITLE
Correct order of tracks when adding albums to playlist

### DIFF
--- a/Sources/WifiRemote/PluginConnection/MpMusicHelper.cs
+++ b/Sources/WifiRemote/PluginConnection/MpMusicHelper.cs
@@ -238,7 +238,7 @@ namespace WifiRemote.PluginConnection
         {
             List<PlayListItem> returnList = new List<PlayListItem>();
             List<Song> songs = new List<Song>();
-            string sql = String.Format("select * from tracks where strAlbumArtist like '%{0}%' AND strAlbum LIKE '%{1}%'",
+            string sql = String.Format("select * from tracks where strAlbumArtist like '%{0}%' AND strAlbum LIKE '%{1}%' order by iDisc,iTrack ASC",
                 DatabaseUtility.RemoveInvalidChars(albumArtist),
                 DatabaseUtility.RemoveInvalidChars(album));
             MusicDatabase.Instance.GetSongsByFilter(sql, out songs, "tracks");


### PR DESCRIPTION
SQL query output for CreatePlaylistItemsFromMusicAlbum action is now ordered by iDisc and iTrack to prevent incorrect playback sequence of tracks in the playlist

My bad... I found only recently that sorting is missing when the albums are added to playlist. If I knew sooner, I could have included this in the previous pull request :-\
